### PR TITLE
fixed type error when markdown is not installed

### DIFF
--- a/ham-mode.el
+++ b/ham-mode.el
@@ -124,7 +124,8 @@ this is an `after-save-hook', that will happen every time the
 buffer is saved, and the file will remain an HTMLized version of
 the current buffer."
   (interactive)
-  (unless (file-executable-p (car ham-mode-markdown-command))
+  (unless (and (car ham-mode-markdown-command)
+	       (file-executable-p (car ham-mode-markdown-command)))
     (error "Can't find the markdown executable! Is it installed? See `ham-mode-markdown-command'"))
   (let ((file (buffer-file-name))
         output return)


### PR DESCRIPTION
If MD is not installed, file-executable-p was being called with nil, the return value of a failed executable-find and throwing an type error instead of the correct error that tells the user markdown is not found.
